### PR TITLE
fix: add dist path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fetch-unfucked",
   "version": "1.2.7",
+  "main": "dist/index.mjs",
   "description": "You know how you always have to write a wrapper around fetch to have sensible defaults? This is that wrapper.",
   "private": false,
   "scripts": {


### PR DESCRIPTION
The `portalpayments/solana-wallet-names` package is using this package.
But when I use it and try to build, the index javascript file can not be found because the configuration file doesn't include the index file path.
So added it to set the path of the index file.